### PR TITLE
31 keeping  data private

### DIFF
--- a/src/class/SimpleData.ts
+++ b/src/class/SimpleData.ts
@@ -62,10 +62,10 @@ import arraysToData from "../helpers/arraysToData.js"
  * ```
  */
 export default class SimpleData {
-    _data: SimpleDataItem[]
+    protected _data: SimpleDataItem[]
     _tempData: SimpleDataItem[]
-    _overwrite: boolean
-    _duration: number
+    protected _overwrite: boolean
+    protected _duration: number
     // Logging
     noLogs: boolean
     verbose: boolean

--- a/src/class/SimpleData.ts
+++ b/src/class/SimpleData.ts
@@ -63,7 +63,7 @@ import arraysToData from "../helpers/arraysToData.js"
  */
 export default class SimpleData {
     protected _data: SimpleDataItem[]
-    _tempData: SimpleDataItem[]
+    protected _tempData: SimpleDataItem[]
     protected _overwrite: boolean
     protected _duration: number
     // Logging

--- a/src/class/SimpleData.ts
+++ b/src/class/SimpleData.ts
@@ -1050,6 +1050,10 @@ export default class SimpleData {
         return this._data
     }
 
+    getTempData(): SimpleDataItem[] {
+        return this._tempData
+    }
+
     getLength(): number {
         return this._data.length
     }

--- a/src/class/SimpleDocument.tsx
+++ b/src/class/SimpleDocument.tsx
@@ -2,7 +2,7 @@ import saveDocument_ from "../methods/exporting/saveDocument.js";
 import checkEnvironment from "../helpers/checkEnvironment.js";
 
 export default class SimpleDocument {
-  _components: (JSX.Element | string)[];
+  protected _components: (JSX.Element | string)[];
   verbose: boolean
   noLogs: boolean
 

--- a/src/helpers/logCall.ts
+++ b/src/helpers/logCall.ts
@@ -30,11 +30,11 @@ export function logCall() {
 
             if (!this.noLogs && !this._overwrite) {
                 if (!key.includes("Chart") && !key.includes("save")) {
-                    if (result instanceof SimpleData) {
-                        result.showTable(this.nbTableItemsToLog)
-                    } else {
-                        showTable(result, this.nbTableItemsToLog)
-                    }
+                    const data =
+                        result instanceof SimpleData
+                            ? result.getTempData()
+                            : result
+                    showTable(data, this.nbTableItemsToLog)
                 }
                 log(
                     `Done in ${(duration / 1000).toFixed(

--- a/src/helpers/logCall.ts
+++ b/src/helpers/logCall.ts
@@ -30,9 +30,11 @@ export function logCall() {
 
             if (!this.noLogs && !this._overwrite) {
                 if (!key.includes("Chart") && !key.includes("save")) {
-                    const data =
-                        result instanceof SimpleData ? result._tempData : result
-                    showTable(data, this.nbTableItemsToLog)
+                    if (result instanceof SimpleData) {
+                        result.showTable(this.nbTableItemsToLog)
+                    } else {
+                        showTable(result, this.nbTableItemsToLog)
+                    }
                 }
                 log(
                     `Done in ${(duration / 1000).toFixed(


### PR DESCRIPTION
To keep the data private, `protected` keyword seems the best option. In Typescript, we have `private` keyword and `#` prefix, too, to make the props private but in that case, they are not accessible in subclasses, which is not good for `SimpleDataNode`.

When using `protected`,  it gives error outside the classes as in the image below. The test `helpers/logCall.ts` is modified because it was accessing `_tempData` directly.
![Screen Shot 2022-08-29 at 15 55 47](https://user-images.githubusercontent.com/29680410/187293068-c441667e-32af-49cb-8116-8dd92cce180d.jpeg)
