### PR TITLE
Default value option for handleMissingKeys and missing keys handled for checkValues

### DIFF
--- a/src/class/SimpleData.ts
+++ b/src/class/SimpleData.ts
@@ -120,6 +120,7 @@ export default class SimpleData {
                 incomingData,
                 fillMissingKeys,
                 undefined,
+                undefined,
                 !noLogs && verbose
             )
 
@@ -181,7 +182,13 @@ export default class SimpleData {
             throw new Error("Incoming data is empty.")
         }
 
-        handleMissingKeys(data, fillMissingKeys, undefined, this.verbose)
+        handleMissingKeys(
+            data,
+            fillMissingKeys,
+            undefined,
+            undefined,
+            this.verbose
+        )
 
         this._tempData = data // important for decorator
         this.#updateSimpleData(data)

--- a/src/class/SimpleDataNode.ts
+++ b/src/class/SimpleDataNode.ts
@@ -51,7 +51,13 @@ export default class SimpleDataNode extends SimpleData {
             throw new Error("Incoming data is empty.")
         }
 
-        handleMissingKeys(data, fillMissingKeys, undefined, this.verbose)
+        handleMissingKeys(
+            data,
+            fillMissingKeys,
+            undefined,
+            undefined,
+            this.verbose
+        )
 
         this._tempData = data
         this.#updateSimpleData(data)
@@ -102,7 +108,13 @@ export default class SimpleDataNode extends SimpleData {
             throw new Error("Incoming data is empty.")
         }
 
-        handleMissingKeys(data, fillMissingKeys, undefined, this.verbose)
+        handleMissingKeys(
+            data,
+            fillMissingKeys,
+            undefined,
+            undefined,
+            this.verbose
+        )
 
         this._tempData = data // important for decorator
         this.#updateSimpleData(data)

--- a/src/helpers/handleMissingKeys.ts
+++ b/src/helpers/handleMissingKeys.ts
@@ -1,4 +1,4 @@
-import { SimpleDataItem } from "../types/SimpleData.types.js"
+import { SimpleDataItem, SimpleDataValue } from "../types/SimpleData.types.js"
 import isEqual from "lodash.isequal"
 import log from "./log.js"
 import getUniqueKeys from "./getUniqueKeys.js"
@@ -6,6 +6,7 @@ import getUniqueKeys from "./getUniqueKeys.js"
 export default function handleMissingKeys(
     data: SimpleDataItem[],
     fillMissingKeys = false,
+    defaultValue?: SimpleDataValue,
     uniqueKeys?: string[],
     verbose?: boolean
 ) {
@@ -31,10 +32,10 @@ export default function handleMissingKeys(
 
         const missingKeys = uniqueKeys.filter((k) => !currentKeys.includes(k))
         for (const key of missingKeys) {
-            data[i][key] = undefined
+            data[i][key] = defaultValue
             verbose &&
                 log(
-                    `Missing key ${key} for item index ${i}. Adding value as undefined.`
+                    `Missing key ${key} for item index ${i}. Adding value as ${defaultValue}.`
                 )
         }
     }

--- a/src/methods/cleaning/checkValues.ts
+++ b/src/methods/cleaning/checkValues.ts
@@ -3,6 +3,7 @@ import getArray from "../exporting/getArray.js"
 import toPercentage from "../../helpers/toPercentage.js"
 import hasKey from "../../helpers/hasKey.js"
 import { shuffle } from "d3-array"
+import handleMissingKeys from "../../helpers/handleMissingKeys.js"
 
 export default function checkValues(
     data: SimpleDataItem[],
@@ -41,7 +42,7 @@ export default function checkValues(
         checks["count"] = array.length
 
         const uniques = array.filter((d, i) => array.indexOf(d) === i)
-        // because NaN is ignored in the line above. And we need to pass it as a string otherwise it will be ignored again.
+        // because NaN is ignored in the line above. We need to pass it as a string otherwise it will be ignored again.
         if (array.includes(NaN)) {
             uniques.push("NaN")
         }
@@ -84,5 +85,7 @@ export default function checkValues(
         allChecks.push(checks)
     }
 
-    return allChecks
+    // We make sure all objects share the same keys.
+
+    return handleMissingKeys(allChecks, true, "0 | 0%")
 }

--- a/src/methods/restructuring/addItems.ts
+++ b/src/methods/restructuring/addItems.ts
@@ -20,6 +20,7 @@ export default function addItems(
         dataToBeAdded = handleMissingKeys(
             dataToBeAdded,
             fillMissingKeys,
+            undefined,
             uniqueKeys
         )
     }

--- a/test/unit/helpers/handleMissingKeys.test.ts
+++ b/test/unit/helpers/handleMissingKeys.test.ts
@@ -30,6 +30,15 @@ describe("handleMissingKeys", function () {
         ])
     })
 
+    it("should fill missing keys with specific value", function () {
+        const data = [{ key1: 1, key2: 2 }, { key1: 2 }]
+        const newData = handleMissingKeys(data, true, "hi!")
+        assert.deepEqual(newData, [
+            { key1: 1, key2: 2 },
+            { key1: 2, key2: "hi!" },
+        ])
+    })
+
     it("should fill missing keys if first item is not complete", function () {
         const data = [{ key1: 2 }, { key1: 1, key2: 2 }]
         const newData = handleMissingKeys(data, true)
@@ -41,7 +50,7 @@ describe("handleMissingKeys", function () {
 
     it("should fill missing keys with unique keys", function () {
         const data = [{ key1: 2 }, { key1: 1, key2: 2 }]
-        const newData = handleMissingKeys(data, true, [
+        const newData = handleMissingKeys(data, true, undefined, [
             "key1",
             "key2",
             "peanut",

--- a/test/unit/methods/cleaning/checkValues.test.ts
+++ b/test/unit/methods/cleaning/checkValues.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert"
 import checkValues from "../../../../src/methods/cleaning/checkValues.js"
+import loadDataFromUrlNode from "../../../../src/methods/importing/loadDataFromUrlNode.js"
 
 describe("checkValues", function () {
     it("should check the type of values", () => {
@@ -58,5 +59,77 @@ describe("checkValues", function () {
         }
         const dataChecked = checkValues(data, 100, true)
         assert.deepEqual(dataChecked[0].count, 100)
+    })
+
+    it("should check values and all items should have the same keys", async function () {
+        const data = await loadDataFromUrlNode(
+            "https://raw.githubusercontent.com/nshiab/simple-data-analysis.js/main/data/employees.csv",
+            false
+        )
+
+        const dataChecked = checkValues(data)
+
+        assert.deepEqual(dataChecked, [
+            {
+                key: "Name",
+                count: 51,
+                uniques: "50 | 98%",
+                string: "48 | 94%",
+                number: 0,
+                NaN: "1 | 2%",
+                null: "1 | 2%",
+                undefined: "1 | 2%",
+            },
+            {
+                key: "Hire date",
+                count: 51,
+                uniques: "46 | 90%",
+                string: "47 | 92%",
+                number: 0,
+                null: "1 | 2%",
+                NaN: "2 | 4%",
+                undefined: "1 | 2%",
+            },
+            {
+                key: "Job",
+                count: 51,
+                uniques: "13 | 25%",
+                string: "47 | 92%",
+                number: 0,
+                NaN: "2 | 4%",
+                null: "1 | 2%",
+                undefined: "1 | 2%",
+            },
+            {
+                key: "Salary",
+                count: 51,
+                uniques: "36 | 71%",
+                string: "49 | 96%",
+                number: 0,
+                NaN: "1 | 2%",
+                undefined: "1 | 2%",
+                null: "0 | 0%",
+            },
+            {
+                key: "Departement or unit",
+                count: 51,
+                uniques: "14 | 27%",
+                string: "47 | 92%",
+                number: 0,
+                null: "2 | 4%",
+                undefined: "1 | 2%",
+                NaN: "1 | 2%",
+            },
+            {
+                key: "End-of_year-BONUS?",
+                count: 51,
+                uniques: "50 | 98%",
+                string: "48 | 94%",
+                number: 0,
+                undefined: "1 | 2%",
+                NaN: "1 | 2%",
+                null: "1 | 2%",
+            },
+        ])
     })
 })


### PR DESCRIPTION
handleMissingKeys can take a default value to fill in missing keys and the result of checkValues is passed to handleMissingKeys before being returned.