### PR TITLE
Values must be numbers for addBins, addOutliers, addProportions, addQuantiles, addVariation, excludeOutliers, sortValues, getMax, getMean, getMedian, getMin, getQuantile, getSum

### DIFF
--- a/src/class/SimpleData.ts
+++ b/src/class/SimpleData.ts
@@ -518,15 +518,18 @@ export default class SimpleData {
     @logCall()
     excludeOutliers({
         key,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         key: string
+        nbTestedValues?: number
         overwrite?: boolean
     }): this {
         this._overwrite = overwrite
         this._tempData = excludeOutliers_(
             cloneDeep(this._data),
             key,
+            nbTestedValues,
             this.verbose
         )
         overwrite && this.#updateSimpleData(this._tempData)
@@ -597,12 +600,12 @@ export default class SimpleData {
     mergeItems({
         dataToBeMerged,
         commonKey,
-        nbValuesTestedForTypeOf = 10000,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         dataToBeMerged: SimpleDataItem[] | SimpleData
         commonKey: string
-        nbValuesTestedForTypeOf?: number
+        nbTestedValues?: number
         overwrite?: boolean
     }): this {
         this._overwrite = overwrite
@@ -611,7 +614,7 @@ export default class SimpleData {
             dataToBeMerged,
             commonKey,
             this.verbose,
-            nbValuesTestedForTypeOf
+            nbTestedValues
         )
         overwrite && this.#updateSimpleData(this._tempData)
 
@@ -769,13 +772,13 @@ export default class SimpleData {
         order = "ascending",
         overwrite = true,
         locale = "fr",
-        nbTestedValue = 10000,
+        nbTestedValues = 10000,
     }: {
         key: string | string[]
         order: "ascending" | "descending"
         overwrite?: boolean
         locale?: string
-        nbTestedValue?: number
+        nbTestedValues?: number
     }): this {
         this._overwrite = overwrite
         this._tempData = sortValues_(
@@ -783,7 +786,7 @@ export default class SimpleData {
             key,
             order,
             locale,
-            nbTestedValue
+            nbTestedValues
         )
         overwrite && this.#updateSimpleData(this._tempData)
 
@@ -835,6 +838,7 @@ export default class SimpleData {
         valueGenerator,
         order = undefined,
         firstValue = undefined,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         key: string
@@ -845,6 +849,7 @@ export default class SimpleData {
         ) => SimpleDataValue
         order?: "ascending" | "descending" | undefined
         firstValue?: SimpleDataValue
+        nbTestedValues?: number
         overwrite?: boolean
     }) {
         this._overwrite = overwrite
@@ -854,7 +859,9 @@ export default class SimpleData {
             newKey,
             valueGenerator,
             order,
-            firstValue
+            firstValue,
+            nbTestedValues,
+            this.verbose
         )
         overwrite && this.#updateSimpleData(this._tempData)
         return this
@@ -895,13 +902,13 @@ export default class SimpleData {
         key1,
         key2,
         overwrite = true,
-        nbValuesTestedForTypeOf = 10000,
+        nbTestedValues = 10000,
     }: {
         key1?: string
         key2?: string | string[]
         overwrite?: boolean
         nbDigits?: number
-        nbValuesTestedForTypeOf?: number
+        nbTestedValues?: number
     } = {}): this {
         this._overwrite = overwrite
         this._tempData = correlation_(
@@ -909,7 +916,7 @@ export default class SimpleData {
             key1,
             key2,
             this.verbose,
-            nbValuesTestedForTypeOf
+            nbTestedValues
         )
         overwrite && this.#updateSimpleData(this._tempData)
 
@@ -921,11 +928,13 @@ export default class SimpleData {
         key,
         newKey,
         nbQuantiles,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         key: string
         newKey: string
         nbQuantiles: number
+        nbTestedValues?: number
         overwrite?: boolean
     }): this {
         this._overwrite = overwrite
@@ -933,7 +942,9 @@ export default class SimpleData {
             cloneDeep(this._data),
             key,
             newKey,
-            nbQuantiles
+            nbQuantiles,
+            nbTestedValues,
+            this.verbose
         )
         overwrite && this.#updateSimpleData(this._tempData)
 
@@ -945,15 +956,24 @@ export default class SimpleData {
         key,
         newKey,
         nbBins,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         key: string
         newKey: string
         nbBins: number
+        nbTestedValues?: number
         overwrite?: boolean
     }): this {
         this._overwrite = overwrite
-        this._tempData = addBins_(cloneDeep(this._data), key, newKey, nbBins)
+        this._tempData = addBins_(
+            cloneDeep(this._data),
+            key,
+            newKey,
+            nbBins,
+            nbTestedValues,
+            this.verbose
+        )
         overwrite && this.#updateSimpleData(this._tempData)
 
         return this
@@ -963,10 +983,12 @@ export default class SimpleData {
     addOutliers({
         key,
         newKey,
+        nbTestedValues = 10000,
         overwrite = true,
     }: {
         key: string
         newKey: string
+        nbTestedValues?: number
         overwrite?: boolean
     }): this {
         this._overwrite = overwrite
@@ -974,6 +996,7 @@ export default class SimpleData {
             cloneDeep(this._data),
             key,
             newKey,
+            nbTestedValues,
             this.verbose
         )
         overwrite && this.#updateSimpleData(this._tempData)
@@ -1111,55 +1134,71 @@ export default class SimpleData {
     getMin({
         key,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getMin_(this._data, key, nbDigits)
+        return getMin_(this._data, key, nbDigits, nbTestedValues, this.verbose)
     }
 
     // No @logCall for methods starting with get. It's not returning a simpleData class
     getMax({
         key,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getMax_(this._data, key, nbDigits)
+        return getMax_(this._data, key, nbDigits, nbTestedValues, this.verbose)
     }
 
     // No @logCall for methods starting with get. It's not returning a simpleData class
     getMean({
         key,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getMean_(this._data, key, nbDigits)
+        return getMean_(this._data, key, nbDigits, nbTestedValues, this.verbose)
     }
 
     // No @logCall for methods starting with get. It's not returning a simpleData class
     getMedian({
         key,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getMedian_(this._data, key, nbDigits)
+        return getMedian_(
+            this._data,
+            key,
+            nbDigits,
+            nbTestedValues,
+            this.verbose
+        )
     }
 
     // No @logCall for methods starting with get. It's not returning a simpleData class
     getSum({
         key,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getSum_(this._data, key, nbDigits)
+        return getSum_(this._data, key, nbDigits, nbTestedValues, this.verbose)
     }
 
     // No @logCall for methods starting with get. It's not returning a simpleData class
@@ -1167,12 +1206,21 @@ export default class SimpleData {
         key,
         quantile,
         nbDigits = 2,
+        nbTestedValues = 10000,
     }: {
         key: string
         quantile: number
         nbDigits?: number
+        nbTestedValues?: number
     }): SimpleDataValue {
-        return getQuantile_(this._data, key, quantile, nbDigits)
+        return getQuantile_(
+            this._data,
+            key,
+            quantile,
+            nbDigits,
+            nbTestedValues,
+            this.verbose
+        )
     }
 
     getDuration() {

--- a/src/methods/analyzing/addBins.ts
+++ b/src/methods/analyzing/addBins.ts
@@ -2,12 +2,15 @@ import { SimpleDataItem } from "../../types/SimpleData.types.js"
 import { range, extent } from "d3-array"
 import hasKey from "../../helpers/hasKey.js"
 import { scaleQuantize } from "d3-scale"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function addBins(
     data: SimpleDataItem[],
     key: string,
     newKey: string,
-    nbBins: number
+    nbBins: number,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataItem[] {
     if (!hasKey(data[0], key)) {
         throw new Error("No key " + key)
@@ -17,6 +20,10 @@ export default function addBins(
     }
     if (nbBins < 1) {
         throw new Error("nbBins should always be > 0.")
+    }
+
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     const [min, max] = extent(data.map((d) => d[key] as number))

--- a/src/methods/analyzing/addOutliers.ts
+++ b/src/methods/analyzing/addOutliers.ts
@@ -3,11 +3,13 @@ import { SimpleDataItem } from "../../types/SimpleData.types.js"
 import { quantile, extent } from "d3-array"
 import toPercentage from "../../helpers/toPercentage.js"
 import hasKey from "../../helpers/hasKey.js"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function addOutliers(
     data: SimpleDataItem[],
     key: string,
     newKey: string,
+    nbTestedValues = 10000,
     verbose = false
 ): SimpleDataItem[] {
     if (!hasKey(data[0], key)) {
@@ -15,6 +17,9 @@ export default function addOutliers(
     }
     if (hasKey(data[0], newKey)) {
         throw new Error("Already a key named " + key)
+    }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     const values = data.map((d) => d[key]) as Iterable<number>

--- a/src/methods/analyzing/addProportions.ts
+++ b/src/methods/analyzing/addProportions.ts
@@ -46,9 +46,9 @@ export default function addProportions(
                         ". You need to choose another suffix."
                 )
             }
-            if (!checkTypeOfKey(data, key, "number", 0.5, nbTestedValues)) {
+            if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues)) {
                 throw new Error(
-                    "The majority of values inside " + key + " are not numbers."
+                    "At least one value in " + key + " is not a number."
                 )
             }
         }
@@ -93,11 +93,9 @@ export default function addProportions(
             throw new Error("No key named " + options.key + " in the data")
         }
 
-        if (!checkTypeOfKey(data, options.key, "number", 0.5, nbTestedValues)) {
+        if (!checkTypeOfKey(data, options.key, "number", 1, nbTestedValues)) {
             throw new Error(
-                "The majority of values inside " +
-                    options.key +
-                    " are not numbers."
+                `At least one value in ${options.key} is not a number.`
             )
         }
 

--- a/src/methods/analyzing/addQuantiles.ts
+++ b/src/methods/analyzing/addQuantiles.ts
@@ -2,12 +2,15 @@ import { SimpleDataItem } from "../../types/SimpleData.types.js"
 import { range } from "d3-array"
 import { scaleQuantile } from "d3-scale"
 import hasKey from "../../helpers/hasKey.js"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function addQuantiles(
     data: SimpleDataItem[],
     key: string,
     newKey: string,
-    nbQuantiles: number
+    nbQuantiles: number,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataItem[] {
     if (!hasKey(data[0], key)) {
         throw new Error("No key " + key)
@@ -17,6 +20,9 @@ export default function addQuantiles(
     }
     if (nbQuantiles < 1) {
         throw new Error("nbQuantiles should always be > 0.")
+    }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     const quantileGenerator = scaleQuantile()

--- a/src/methods/analyzing/addVariation.ts
+++ b/src/methods/analyzing/addVariation.ts
@@ -1,6 +1,7 @@
 import { SimpleDataItem, SimpleDataValue } from "../../types/SimpleData.types"
 import { pairs } from "d3-array"
 import hasKey from "../../helpers/hasKey.js"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function addVariation(
     data: SimpleDataItem[],
@@ -8,7 +9,9 @@ export default function addVariation(
     newKey: string,
     valueGenerator: (a: SimpleDataValue, b: SimpleDataValue) => SimpleDataValue,
     order: "ascending" | "descending" | undefined = undefined,
-    firstValue: SimpleDataValue = undefined
+    firstValue: SimpleDataValue = undefined,
+    nbTestedValues = 10000,
+    verbose = false
 ) {
     if (!hasKey(data[0], key)) {
         throw new Error("No key " + key + " in the data")
@@ -19,6 +22,9 @@ export default function addVariation(
                 newKey +
                 " already exists in the data. Write a new name."
         )
+    }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     if (order === "ascending") {

--- a/src/methods/analyzing/excludeOutliers.ts
+++ b/src/methods/analyzing/excludeOutliers.ts
@@ -3,14 +3,19 @@ import { SimpleDataItem } from "../../types/SimpleData.types.js"
 import { quantile, extent } from "d3-array"
 import toPercentage from "../../helpers/toPercentage.js"
 import hasKey from "../../helpers/hasKey.js"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function excludeOutliers(
     data: SimpleDataItem[],
     key: string,
+    nbTestedValues = 10000,
     verbose = false
 ): SimpleDataItem[] {
     if (!hasKey(data[0], key)) {
         throw new Error("No key " + key)
+    }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     const values = data.map((d) => d[key]) as Iterable<number>

--- a/src/methods/analyzing/sortValues.ts
+++ b/src/methods/analyzing/sortValues.ts
@@ -8,7 +8,7 @@ export default function sortValues(
     key: string | string[],
     order: "ascending" | "descending",
     locale = "fr",
-    nbTestedValue = 100
+    nbTestedValue = 10000
 ): SimpleDataItem[] {
     let keysToSort
     if (typeof key === "string") {

--- a/src/methods/exporting/getMax.ts
+++ b/src/methods/exporting/getMax.ts
@@ -4,20 +4,25 @@ import {
 } from "../../types/SimpleData.types.js"
 import hasKey from "../../helpers/hasKey.js"
 import { max } from "d3-array"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function getMax(
     data: SimpleDataItem[],
     key: string,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
     }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
+    }
 
-    const result = max(data, (d) => d[key] as number | Date)
-    if (result instanceof Date) {
-        return result.getTime()
-    } else if (typeof result === "number") {
+    const result = max(data, (d) => d[key] as number)
+
+    if (typeof result === "number") {
         return parseFloat(result.toFixed(nbDigits))
     } else {
         return result

--- a/src/methods/exporting/getMean.ts
+++ b/src/methods/exporting/getMean.ts
@@ -4,21 +4,25 @@ import {
 } from "../../types/SimpleData.types.js"
 import hasKey from "../../helpers/hasKey.js"
 import { mean } from "d3-array"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function getMean(
     data: SimpleDataItem[],
     key: string,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
     }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
+    }
 
-    const result = mean(data, (d) => d[key] as number) as number | Date
+    const result = mean(data, (d) => d[key] as number) as number
 
-    if (result instanceof Date) {
-        return result.getTime()
-    } else if (typeof result === "number") {
+    if (typeof result === "number") {
         return parseFloat(result.toFixed(nbDigits))
     } else {
         return result

--- a/src/methods/exporting/getMedian.ts
+++ b/src/methods/exporting/getMedian.ts
@@ -4,21 +4,25 @@ import {
 } from "../../types/SimpleData.types.js"
 import hasKey from "../../helpers/hasKey.js"
 import { median } from "d3-array"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function getMedian(
     data: SimpleDataItem[],
     key: string,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
     }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
+    }
 
-    const result = median(data, (d) => d[key] as number) as number | Date
+    const result = median(data, (d) => d[key] as number) as number
 
-    if (result instanceof Date) {
-        return result.getTime()
-    } else if (typeof result === "number") {
+    if (typeof result === "number") {
         return parseFloat(result.toFixed(nbDigits))
     } else {
         return result

--- a/src/methods/exporting/getMin.ts
+++ b/src/methods/exporting/getMin.ts
@@ -4,21 +4,25 @@ import {
 } from "../../types/SimpleData.types.js"
 import hasKey from "../../helpers/hasKey.js"
 import { min } from "d3-array"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function getMin(
     data: SimpleDataItem[],
     key: string,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
     }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
+    }
 
-    const result = min(data, (d) => d[key] as number | Date)
+    const result = min(data, (d) => d[key] as number)
 
-    if (result instanceof Date) {
-        return result.getTime()
-    } else if (typeof result === "number") {
+    if (typeof result === "number") {
         return parseFloat(result.toFixed(nbDigits))
     } else {
         return result

--- a/src/methods/exporting/getQuantile.ts
+++ b/src/methods/exporting/getQuantile.ts
@@ -4,15 +4,21 @@ import {
 } from "../../types/SimpleData.types.js"
 import hasKey from "../../helpers/hasKey.js"
 import { quantile as d3Quantile } from "d3-array"
+import checkTypeOfKey from "../../helpers/checkTypeOfKey.js"
 
 export default function getQuantile(
     data: SimpleDataItem[],
     key: string,
     quantile: number,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
+    }
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     if (quantile === undefined) {
@@ -21,13 +27,9 @@ export default function getQuantile(
         )
     }
 
-    const result = d3Quantile(data, quantile, (d) => d[key] as number) as
-        | number
-        | Date
+    const result = d3Quantile(data, quantile, (d) => d[key] as number)
 
-    if (result instanceof Date) {
-        return result.getTime()
-    } else if (typeof result === "number") {
+    if (typeof result === "number") {
         return parseFloat(result.toFixed(nbDigits))
     } else {
         return result

--- a/src/methods/exporting/getSum.ts
+++ b/src/methods/exporting/getSum.ts
@@ -9,14 +9,15 @@ import { sum } from "d3-array"
 export default function getSum(
     data: SimpleDataItem[],
     key: string,
-    nbDigits = 2
+    nbDigits = 2,
+    nbTestedValues = 10000,
+    verbose = false
 ): SimpleDataValue {
     if (!hasKey(data[0], key)) {
         throw new Error(`No key ${key} in data`)
     }
-
-    if (!checkTypeOfKey(data, key, "number", 0.5)) {
-        throw new Error(`The majority of values inside ${key} are not numbers.`)
+    if (!checkTypeOfKey(data, key, "number", 1, nbTestedValues, verbose)) {
+        throw new Error(`At least one value in ${key} is not a number.`)
     }
 
     const result = sum(data, (d) => d[key] as number)

--- a/test/unit/methods/exporting/getMax.test.ts
+++ b/test/unit/methods/exporting/getMax.test.ts
@@ -17,12 +17,10 @@ describe("getMax", function () {
         assert.deepEqual(maxValue, 99)
     })
 
-    it("should return max value 9 from key with different types", function () {
-        const maxValue = getMax(data, "key2")
-        assert.deepEqual(maxValue, 9)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getMax(data, "key2"))
     })
-    it("should return max value when working with dates", function () {
-        const maxValue = getMax(data, "key3")
-        assert.deepEqual(maxValue, 1659830400000)
+    it("should throw an error when working with dates", function () {
+        assert.throws(() => getMax(data, "key3"))
     })
 })

--- a/test/unit/methods/exporting/getMean.test.ts
+++ b/test/unit/methods/exporting/getMean.test.ts
@@ -17,12 +17,10 @@ describe("getMean", function () {
         assert.deepEqual(meanValue, 39.9)
     })
 
-    it("should return mean value 16.5 from key with different types", function () {
-        const meanValue = getMean(data, "key2")
-        assert.deepEqual(meanValue, 16.5)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getMean(data, "key2"))
     })
-    it("should return mean value when working with dates", function () {
-        const meanValue = getMean(data, "key3")
-        assert.deepEqual(meanValue, 1659571200000)
+    it("should throw an error when working with dates", function () {
+        assert.throws(() => getMean(data, "key3"))
     })
 })

--- a/test/unit/methods/exporting/getMedian.test.ts
+++ b/test/unit/methods/exporting/getMedian.test.ts
@@ -17,12 +17,10 @@ describe("getMedian", function () {
         assert.deepEqual(medianValue, 40)
     })
 
-    it("should return median value 33 from key with different types", function () {
-        const medianValue = getMedian(data, "key2")
-        assert.deepEqual(medianValue, 33)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getMedian(data, "key2"))
     })
-    it("should return median value with dates", function () {
-        const medianValue = getMedian(data, "key3")
-        assert.deepEqual(medianValue, 1659571200000)
+    it("should throw an error when working with dates", function () {
+        assert.throws(() => getMedian(data, "key3"))
     })
 })

--- a/test/unit/methods/exporting/getMin.test.ts
+++ b/test/unit/methods/exporting/getMin.test.ts
@@ -17,12 +17,10 @@ describe("getMin", function () {
         assert.deepEqual(minValue, 44)
     })
 
-    it("should return min value -11.1 from key with different types", function () {
-        const minValue = getMin(data, "key2")
-        assert.deepEqual(minValue, -11.1)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getMin(data, "key2"))
     })
-    it("should return min value when working with dates", function () {
-        const minValue = getMin(data, "key3")
-        assert.deepEqual(minValue, 1659312000000)
+    it("should throw an error when working with dates", function () {
+        assert.throws(() => getMin(data, "key3"))
     })
 })

--- a/test/unit/methods/exporting/getQuantile.test.ts
+++ b/test/unit/methods/exporting/getQuantile.test.ts
@@ -17,12 +17,10 @@ describe("getQuantile", function () {
         assert.deepEqual(medianValue, 40)
     })
 
-    it("should return median value 33 from key with different types", function () {
-        const medianValue = getQuantile(data, "key2", 0.5)
-        assert.deepEqual(medianValue, 33)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getQuantile(data, "key2", 0.5))
     })
-    it("should return median value with dates", function () {
-        const medianValue = getQuantile(data, "key3", 0.5)
-        assert.deepEqual(medianValue, 1659571200000)
+    it("should throw an error when working with dates", function () {
+        assert.throws(() => getQuantile(data, "key3", 0.5))
     })
 })

--- a/test/unit/methods/exporting/getSum.test.ts
+++ b/test/unit/methods/exporting/getSum.test.ts
@@ -17,8 +17,7 @@ describe("getSum", function () {
         assert.deepEqual(sum, 473)
     })
 
-    it("should return the sum from key with different types", function () {
-        const sum = getSum(data, "key2")
-        assert.deepEqual(sum, 8.9)
+    it("should throw an error when different types", function () {
+        assert.throws(() => getSum(data, "key2"))
     })
 })


### PR DESCRIPTION
These methods will throw an error when the values are not numbers: addBins, addOutliers, addProportions, addQuantiles, addVariation, excludeOutliers, sortValues, getMax, getMean, getMedian, getMin, getQuantile, getSum.